### PR TITLE
Add missing dependencies from php80

### DIFF
--- a/nethserver-remi-php80-php-fpm.spec
+++ b/nethserver-remi-php80-php-fpm.spec
@@ -15,6 +15,8 @@ Requires: php80-php-pdo, php80-php-tidy, php80-php-mysqlnd
 Requires: php80-php-soap, php80-php-pgsql
 Requires: php80-php-pecl-apcu, php80-php-intl
 Requires: php80-php-opcache
+# specific dependencies from remi to get same PHP modules list of RH SCL
+Requires: php80-php-xml, php80-php-pecl-zip, php80-php-process
 
 %description
 Basic support for PHP 80 using SCL of remi repository


### PR DESCRIPTION
I think we miss 

```
php80-php-xml
php80-php-pecl-zip
php80-php-process
```

I did a comparison by enabling `scl enable rh-php73 bash` and `scl enable php80 bash` then by installing the three rpm I can compare what I miss

```
[root@ns7dev ~]# diff php73 php80+xml+zip+process 
8a9
> json
30d30
< json
51d50
< zip
56d54
< wddx
58a57
> zip
```

wddx is deprecated https://pecl.php.net/package/wddx 

from remi [	wddx	1.0.0-dev	Dropped from 7.4, no release planed](https://blog.remirepo.net/post/2019/05/23/PHP-extensions-status-with-upcoming-PHP-7.4)

https://github.com/NethServer/dev/issues/6356